### PR TITLE
Configure app secrets via env vars

### DIFF
--- a/newsfeed/src/main/java/com/financeapp/newsfeed/controller/NewsController.java
+++ b/newsfeed/src/main/java/com/financeapp/newsfeed/controller/NewsController.java
@@ -4,6 +4,7 @@ import com.financeapp.newsfeed.model.NewsArticle;
 import com.financeapp.newsfeed.service.MailService;
 import com.financeapp.newsfeed.service.NewsService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +26,9 @@ public class NewsController {
     @Autowired
     private MailService mailService;
 
+    @Value("${MAIL_FROM_ADDRESS}")
+    private String fromAddress;
+
     @GetMapping("/email")
     public ResponseEntity<String> sendNewsSummaryEmail() {
         List<String> keywords = Arrays.stream(newsService.getKeywordList().split(","))
@@ -37,7 +41,7 @@ public class NewsController {
 
         try {
             mailService.sendNewsSummary(
-                    "bikashshah15b@gmail.com",
+                    fromAddress,
                     "📩 Daily Finance News Summary",
                     summary
             );

--- a/newsfeed/src/main/java/com/financeapp/newsfeed/service/MailService.java
+++ b/newsfeed/src/main/java/com/financeapp/newsfeed/service/MailService.java
@@ -2,6 +2,7 @@ package com.financeapp.newsfeed.service;
 
 import jakarta.mail.MessagingException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,12 @@ public class MailService {
     @Autowired
     private JavaMailSender mailSender;
 
+    @Value("${MAIL_FROM_ADDRESS}")
+    private String fromAddress;
+
     public void sendNewsSummary(String toEmail, String subject, String summaryContent) throws MessagingException {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom("bikashshah15b@gmail.com");
+        message.setFrom(fromAddress);
         message.setTo(toEmail);
         message.setSubject(subject);
         message.setText(summaryContent);

--- a/newsfeed/src/main/java/com/financeapp/newsfeed/service/SchedulerService.java
+++ b/newsfeed/src/main/java/com/financeapp/newsfeed/service/SchedulerService.java
@@ -2,6 +2,7 @@ package com.financeapp.newsfeed.service;
 
 import com.financeapp.newsfeed.model.NewsArticle;
 import jakarta.mail.MessagingException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,9 @@ import java.util.List;
 public class SchedulerService {
     private final MailService mailService;
     private final NewsService newsService;
+
+    @Value("${MAIL_FROM_ADDRESS}")
+    private String fromAddress;
 
     public SchedulerService(MailService mailService, NewsService newsService) {
         this.mailService = mailService;
@@ -30,7 +34,7 @@ public class SchedulerService {
 
         try {
             mailService.sendNewsSummary(
-                    "bikashshah15b@gmail.com",
+                    fromAddress,
                     "📩 Daily Finance News Summary",
                     summary
             );

--- a/newsfeed/src/main/resources/application.properties
+++ b/newsfeed/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=newsfeed 
-newsapi.key=46a823f0c3374233ab04c991838eef4f
+newsapi.key=${NEWSAPI_KEY}
 
 
 news.keywords=fed,interest rate,inflation,recession,GDP,federal reserve,\
@@ -12,7 +12,7 @@ portfolio,equity
 # --- Email Settings ---
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=bikashshah15b@gmail.com
-spring.mail.password=vsam tvpb rdjn ocox
+spring.mail.username=${SPRING_MAIL_USERNAME}
+spring.mail.password=${SPRING_MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
## Summary
- parametrize `application.properties` to read sensitive values from environment variables
- inject `MAIL_FROM_ADDRESS` into mail and scheduling components
- use the injected address when sending emails

## Testing
- `mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887ac1434288325a463060e1b8ddad3