### PR TITLE
Enable local profile usage

### DIFF
--- a/newsfeed/src/main/resources/application-local.properties
+++ b/newsfeed/src/main/resources/application-local.properties
@@ -1,3 +1,5 @@
+# Activate the local profile when running the application
+spring.profiles.active=local
 spring.application.name=newsfeed
 newsapi.key=LOCAL_NEWSAPI_KEY
 


### PR DESCRIPTION
## Summary
- activate `local` profile in `application-local.properties` so the application can be run with local configuration

## Testing
- `mvn -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887b6759bdc8325ae63cc39af560d75