### PR TITLE
Update local properties for easier local development

### DIFF
--- a/newsfeed/src/main/resources/application-local.properties
+++ b/newsfeed/src/main/resources/application-local.properties
@@ -1,5 +1,8 @@
+spring.config.activate.on-profile=local
 spring.application.name=newsfeed
-newsapi.key=LOCAL_NEWSAPI_KEY
+# API key used when running locally. Replace the default value or export the
+# NEWSAPI_KEY environment variable to override it.
+newsapi.key=${NEWSAPI_KEY:LOCAL_NEWSAPI_KEY}
 
 news.keywords=fed,interest rate,inflation,recession,GDP,federal reserve,\
     economy,economic,market,nasdaq,s&p,dow,stock,bond,yields,earnings,\
@@ -9,10 +12,12 @@ news.keywords=fed,interest rate,inflation,recession,GDP,federal reserve,\
     portfolio,equity
 
 # --- Email Settings ---
-MAIL_FROM_ADDRESS=bikashshah15b@gmail.com
+# Sender address for outgoing mail. Override via the MAIL_FROM_ADDRESS env var.
+MAIL_FROM_ADDRESS=${MAIL_FROM_ADDRESS:localuser@example.com}
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=bikashshah15b@gmail.com
-spring.mail.password=vsam tvpb rdjn ocox
+# Local SMTP credentials. Override via SPRING_MAIL_USERNAME and SPRING_MAIL_PASSWORD.
+spring.mail.username=${SPRING_MAIL_USERNAME:localuser@example.com}
+spring.mail.password=${SPRING_MAIL_PASSWORD:localpassword}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
## Summary
- configure `application-local.properties` for local profile
- provide environment variable overrides for email and API keys

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887b6759bdc8325ae63cc39af560d75